### PR TITLE
fix: glitch for prettified params

### DIFF
--- a/internal/sift/pretty_logs.go
+++ b/internal/sift/pretty_logs.go
@@ -15,10 +15,8 @@ func prettifyLogEntry(entry logparse.LogEntry, baseStyle lipgloss.Style) string 
 		Render(entry.Time.Format(time.TimeOnly + ".000"))
 
 	additionalFields := ""
-	for key, value := range entry.Additional {
-		if v, ok := value.(string); ok {
-			additionalFields += fmt.Sprintf("%s=%s ", key, v)
-		}
+	for _, field := range entry.Additional {
+		additionalFields += fmt.Sprintf("%s=%s ", field.Key, field.Value)
 	}
 	if additionalFields != "" {
 		additionalFields = styleSecondary.Inherit(baseStyle).Render(" | " + additionalFields[:len(additionalFields)-1])

--- a/internal/sift/test_stack.go
+++ b/internal/sift/test_stack.go
@@ -1,7 +1,6 @@
 package sift
 
 import (
-	"log/slog"
 	"strings"
 )
 
@@ -33,7 +32,6 @@ func (ts *testStack) Push(testName string) {
 func (ts *testStack) PopUntilPrefix(testName string) string {
 	for ts.lastElement > -1 {
 		if strings.HasPrefix(testName, ts.stack[ts.lastElement]+"/") {
-			slog.Debug("popUntilPrefix", "testName", testName, "stack", ts.stack[:ts.lastElement+1])
 			return ts.stack[ts.lastElement] + "/"
 		}
 		ts.stack[ts.lastElement] = ""

--- a/internal/tests/test_manager_test.go
+++ b/internal/tests/test_manager_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/timtatt/sift/pkg/logparse"
 )
 
 func TestShouldSkipLogLine(t *testing.T) {
@@ -211,7 +212,7 @@ func TestAddTestOutput(t *testing.T) {
 		assert.Equal(t, "INFO", logs[0].Level)
 		assert.Equal(t, "2025-10-05T09:52:58+11:00", logs[0].Time.Format(time.RFC3339))
 		assert.Equal(t, "This is an info message", logs[0].Message)
-		assert.Equal(t, "value1", logs[0].Additional["key1"])
+		assert.Contains(t, logs[0].Additional, logparse.LogEntryAdditionalProp{Key: "key1", Value: "value1"})
 	})
 }
 

--- a/pkg/logparse/slog_json_test.go
+++ b/pkg/logparse/slog_json_test.go
@@ -50,19 +50,19 @@ func TestParseSlogJSON(t *testing.T) {
 
 func TestParseSlogJSON_Examples(t *testing.T) {
 	tests := []struct {
-		name           string
-		log            string
-		expectedMsg    string
-		expectedLevel  string
-		expectedFields map[string]any
+		name               string
+		log                string
+		expectedMsg        string
+		expectedLevel      string
+		expectedAdditional []LogEntryAdditionalProp
 	}{
 		{
 			name:          "info message with string field",
 			log:           `{"time":"2025-10-05T09:52:58.045477+11:00","level":"INFO","msg":"This is an info message","key1":"value1"}`,
 			expectedMsg:   "This is an info message",
 			expectedLevel: "INFO",
-			expectedFields: map[string]any{
-				"key1": "value1",
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key1", Value: "value1"},
 			},
 		},
 		{
@@ -70,8 +70,8 @@ func TestParseSlogJSON_Examples(t *testing.T) {
 			log:           `{"time":"2025-10-05T09:52:58.045984+11:00","level":"DEBUG","msg":"This is a debug message","key3":42}`,
 			expectedMsg:   "This is a debug message",
 			expectedLevel: "DEBUG",
-			expectedFields: map[string]any{
-				"key3": float64(42), // JSON numbers are decoded as float64
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key3", Value: "42"},
 			},
 		},
 		{
@@ -79,8 +79,8 @@ func TestParseSlogJSON_Examples(t *testing.T) {
 			log:           `{"time":"2025-10-05T09:52:58.046013+11:00","level":"WARN","msg":"This is a warning message","key4":3.14}`,
 			expectedMsg:   "This is a warning message",
 			expectedLevel: "WARN",
-			expectedFields: map[string]any{
-				"key4": 3.14,
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key4", Value: "3.14"},
 			},
 		},
 		{
@@ -88,8 +88,8 @@ func TestParseSlogJSON_Examples(t *testing.T) {
 			log:           `{"time":"2025-10-05T09:52:58.046107+11:00","level":"ERROR","msg":"This is an error message","key5":"value5"}`,
 			expectedMsg:   "This is an error message",
 			expectedLevel: "ERROR",
-			expectedFields: map[string]any{
-				"key5": "value5",
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key5", Value: "value5"},
 			},
 		},
 	}
@@ -102,11 +102,7 @@ func TestParseSlogJSON_Examples(t *testing.T) {
 			assert.Equal(t, tt.expectedMsg, entry.Message)
 			assert.Equal(t, tt.expectedLevel, entry.Level)
 			assert.False(t, entry.Time.IsZero(), "Time should not be zero")
-
-			for key, expectedValue := range tt.expectedFields {
-				assert.Contains(t, entry.Additional, key)
-				assert.Equal(t, expectedValue, entry.Additional[key])
-			}
+			assert.ElementsMatch(t, tt.expectedAdditional, entry.Additional)
 		})
 	}
 }

--- a/pkg/logparse/slog_text.go
+++ b/pkg/logparse/slog_text.go
@@ -17,7 +17,7 @@ func ParseSlogText(reader io.Reader) (LogEntry, error) {
 	}
 
 	entry := LogEntry{
-		Additional: make(map[string]any),
+		Additional: []LogEntryAdditionalProp{},
 	}
 
 	for _, item := range items {
@@ -32,7 +32,10 @@ func ParseSlogText(reader io.Reader) (LogEntry, error) {
 		case "msg":
 			entry.Message = item.value
 		default:
-			entry.Additional[item.key] = item.value
+			entry.Additional = append(entry.Additional, LogEntryAdditionalProp{
+				Key:   item.key,
+				Value: item.value,
+			})
 		}
 	}
 

--- a/pkg/logparse/slog_text_test.go
+++ b/pkg/logparse/slog_text_test.go
@@ -51,19 +51,19 @@ func TestParseSlogText(t *testing.T) {
 
 func TestParseSlogText_Examples(t *testing.T) {
 	tests := []struct {
-		name           string
-		log            string
-		expectedMsg    string
-		expectedLevel  string
-		expectedFields map[string]any
+		name               string
+		log                string
+		expectedMsg        string
+		expectedLevel      string
+		expectedAdditional []LogEntryAdditionalProp
 	}{
 		{
 			name:          "info message with string field",
 			log:           `time=2025-10-05T09:52:58.046+11:00 level=INFO msg="This is an info message" key1=value1`,
 			expectedMsg:   "This is an info message",
 			expectedLevel: "INFO",
-			expectedFields: map[string]any{
-				"key1": "value1",
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key1", Value: "value1"},
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestParseSlogText_Examples(t *testing.T) {
 			log:           `time=2025-10-05T09:52:58.046+11:00 level=DEBUG msg="This is a debug message" key3=42`,
 			expectedMsg:   "This is a debug message",
 			expectedLevel: "DEBUG",
-			expectedFields: map[string]any{
-				"key3": "42",
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key3", Value: "42"},
 			},
 		},
 		{
@@ -80,8 +80,8 @@ func TestParseSlogText_Examples(t *testing.T) {
 			log:           `time=2025-10-05T09:52:58.046+11:00 level=WARN msg="This is a warning message" key4=3.14`,
 			expectedMsg:   "This is a warning message",
 			expectedLevel: "WARN",
-			expectedFields: map[string]any{
-				"key4": "3.14",
+			expectedAdditional: []LogEntryAdditionalProp{
+				{Key: "key4", Value: "3.14"},
 			},
 		},
 	}
@@ -94,11 +94,7 @@ func TestParseSlogText_Examples(t *testing.T) {
 			assert.Equal(t, tt.expectedMsg, entry.Message)
 			assert.Equal(t, tt.expectedLevel, entry.Level)
 			assert.False(t, entry.Time.IsZero(), "Time should not be zero")
-
-			for key, expectedValue := range tt.expectedFields {
-				assert.Contains(t, entry.Additional, key)
-				assert.Equal(t, expectedValue, entry.Additional[key])
-			}
+			assert.ElementsMatch(t, tt.expectedAdditional, entry.Additional)
 		})
 	}
 }

--- a/samples/logs/json_logger_test.go
+++ b/samples/logs/json_logger_test.go
@@ -44,3 +44,30 @@ func TestStandardSlog(t *testing.T) {
 func TestRawLogging(t *testing.T) {
 	fmt.Println("This is a raw log message")
 }
+
+func TestSlogWith20Attributes(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	logger.Info("Log entry with 20 attributes",
+		slog.String("attr1", "value1"),
+		slog.String("attr2", "value2"),
+		slog.Int("attr3", 3),
+		slog.Int("attr4", 4),
+		slog.Float64("attr5", 5.5),
+		slog.Float64("attr6", 6.6),
+		slog.Bool("attr7", true),
+		slog.Bool("attr8", false),
+		slog.String("attr9", "value9"),
+		slog.String("attr10", "value10"),
+		slog.Int("attr11", 11),
+		slog.Int("attr12", 12),
+		slog.Float64("attr13", 13.13),
+		slog.Float64("attr14", 14.14),
+		slog.String("attr15", "value15"),
+		slog.String("attr16", "value16"),
+		slog.Int("attr17", 17),
+		slog.Int("attr18", 18),
+		slog.String("attr19", "value19"),
+		slog.String("attr20", "value20"),
+	)
+}


### PR DESCRIPTION
Root Cause: the additional fields were being stored as a map and the iterator returned the list in a different order for each render

Fix:
- Store the additional fields in a slice
- Handle parsing numeric types also with new `Stringify` method