### PR TITLE
fix: print entire test outcome in inline mode

### DIFF
--- a/internal/sift/sift.go
+++ b/internal/sift/sift.go
@@ -140,5 +140,12 @@ func Run(ctx context.Context, opts SiftOptions) error {
 		return nil
 	})
 
-	return g.Wait()
+	err := g.Wait()
+	if err != nil {
+		return err
+	}
+
+	m.quitting = false
+	fmt.Print(m.View())
+	return nil
 }

--- a/internal/sift/version.go
+++ b/internal/sift/version.go
@@ -1,3 +1,3 @@
 package sift
 
-var Version = "v0.12.0"
+var Version = "v0.12.1"

--- a/internal/sift/view.go
+++ b/internal/sift/view.go
@@ -41,6 +41,7 @@ type siftModel struct {
 
 	ready     bool
 	started   bool
+	quitting  bool
 	viewport  viewport.Model
 	keyBuffer []string
 
@@ -420,8 +421,11 @@ func (m *siftModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.startTime = time.Now()
 	}
 
-	if m.mode == viewModeInline && !m.endTime.IsZero() {
+	if m.quitting {
 		return m, tea.Quit
+	} else if m.mode == viewModeInline && !m.endTime.IsZero() {
+		m.quitting = true
+		return m, nil
 	}
 
 	switch msg := msg.(type) {
@@ -577,7 +581,8 @@ func (m *siftModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.ExitAltScreen
 			}
 			if !m.endTime.IsZero() {
-				return m, tea.Quit
+				m.quitting = true
+				return m, nil
 			}
 		case key.Matches(msg, keys.ClearSearch):
 			// Clear search filter when esc is pressed and not in search mode
@@ -631,6 +636,12 @@ func (m *siftModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *siftModel) View() string {
+	// this is a hack to allow the final output of the inline view to include all lines
+	// the proper way to handle this would be to have a custom renderer for tea which doesn't truncate the lines based on the viewport
+	if m.quitting {
+		return ""
+	}
+
 	if m.mode == viewModeInline {
 		return m.inlineView()
 	}


### PR DESCRIPTION
Currently Bubbletea truncates the viewport based on the terminal window height. Because of this, after the test is completed it can be truncated if it exceeds the terminal window height.

Ref: https://github.com/charmbracelet/bubbletea/blob/main/standard_renderer.go#L186

This is a dirty hack to force the last View() of the model to be empty before quitting. We then do a standard print with the entire View contents before exiting

Mitigates #33 